### PR TITLE
Buffer the JSON read/write paths in bnk2json

### DIFF
--- a/format/src/bin/bnk2json.rs
+++ b/format/src/bin/bnk2json.rs
@@ -138,7 +138,7 @@ fn handle_soundbank(path: path::PathBuf) {
     let mut json_path = output_dir.clone();
     json_path.push("soundbank.json");
     let handle = fs::File::create(&json_path).expect("could not acquire write file handle");
-
+    let handle = io::BufWriter::new(handle);
     serde_json::to_writer_pretty(handle, &soundbank).expect("could not write json to output file");
 }
 
@@ -149,7 +149,7 @@ fn handle_dir(path: path::PathBuf) {
         json_path.push("soundbank.json");
 
         let handle = fs::File::open(&json_path).expect("Could not acquire read file handle");
-
+        let handle = io::BufReader::new(handle);
         serde_json::from_reader::<_, Soundbank>(handle)
             .expect("Could not deserialize input into a soundbank")
     };


### PR DESCRIPTION
### What

`bnk2json` writes `soundbank.json` with `serde_json::to_writer_pretty` against a raw `fs::File` handle, and reads it back with `serde_json::from_reader` against another raw `fs::File` handle. `to_writer_pretty` issues many small writes (one per JSON token, one per indent), and `from_reader` streams the input one chunk at a time. With unbuffered file handles each of those becomes a syscall, which on Windows is extremely expensive — for a `cs_main`-sized soundbank that decompiles to a ~100 MB pretty JSON the syscall overhead dominates wall time. Wrapping the handles in `io::BufWriter` and `io::BufReader` fixes it.

### Direct timing evidence

Standalone `bnk2json.exe` against a real `cs_main`-sized `.bnk` test fixture (1.4 MB binary, ~100 MB pretty JSON, ~30k HIRC objects) on Windows 11, NTFS, release build:

| Step      | Before (v0.3.2 release) | After (this PR) | Speedup |
|-----------|------------------------:|----------------:|--------:|
| Decompile | 158.6 s                 | 1.1 s           | ~150×   |
| Recompile | 239.3 s                 | 1.5 s           | ~165×   |

(Both binaries built `--release`; same fixture, same disk, back-to-back runs.)

### Output unchanged

`soundbank.json` is byte-identical between the v0.3.2 binary and the fixed binary (`md5sum` matches), and round-tripping the fixture through `bnk2json fixture.bnk && bnk2json fixture/` produces a `fixture.created.bnk` whose md5 matches the original input. The fix only changes how bytes reach the kernel; it does not change the bytes themselves.